### PR TITLE
Add Dependabot grouping and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+---
+name: Dependabot Auto-Merge
+
+'on': pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    env:
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7  # v2.3.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and merge eligible updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"

--- a/scripts/configure-branch-protection.sh
+++ b/scripts/configure-branch-protection.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Configures branch protection on master with required status checks (Lint).
+# Required for gh pr merge --auto to wait for CI before merging.
+#
+# Usage: ./scripts/configure-branch-protection.sh [--check]
+#   --check   Only check current settings, don't modify anything
+#
+set -euo pipefail
+
+REPO="brianhartsock/ansible-role-homebrew"
+BRANCH="master"
+REQUIRED_CHECKS=("Lint" )
+
+check_current() {
+    echo "Fetching branch protection for $BRANCH..."
+    protection=$(gh api "repos/$REPO/branches/$BRANCH/protection" 2>&1) || {
+        echo "No branch protection configured on $BRANCH."
+        return 1
+    }
+
+    checks=$(echo "$protection" | jq -r '.required_status_checks.checks // []')
+    if [ "$checks" = "[]" ] || [ -z "$checks" ]; then
+        echo "Branch protection exists but no required status checks are configured."
+        return 1
+    fi
+
+    echo "Current required status checks:"
+    echo "$protection" | jq -r '.required_status_checks.checks[].context'
+
+    missing=0
+    for check in "${REQUIRED_CHECKS[@]}"; do
+        if ! echo "$protection" | jq -r '.required_status_checks.checks[].context' | grep -qx "$check"; then
+            echo "Missing required check: $check"
+            missing=1
+        fi
+    done
+
+    if [ "$missing" -eq 0 ]; then
+        echo "All required checks are configured."
+        return 0
+    fi
+    return 1
+}
+
+configure() {
+    echo "Configuring branch protection on $BRANCH..."
+
+    checks_json=$(printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R '{"context": ., "app_id": -1}' | jq -s '.')
+
+    gh api --method PUT "repos/$REPO/branches/$BRANCH/protection" \
+        --input <(jq -n \
+            --argjson checks "$checks_json" \
+            '{
+                required_status_checks: {
+                    strict: false,
+                    checks: $checks
+                },
+                enforce_admins: false,
+                required_pull_request_reviews: null,
+                restrictions: null
+            }')
+
+    echo "Branch protection configured with required checks: ${REQUIRED_CHECKS[*]}"
+}
+
+if [ "${1:-}" = "--check" ]; then
+    check_current
+else
+    if check_current; then
+        echo "Nothing to do."
+    else
+        configure
+        echo ""
+        echo "Verifying..."
+        check_current
+    fi
+fi


### PR DESCRIPTION
## Summary
- Configure Dependabot to group dependency updates (pip, github-actions) into fewer PRs
- Add auto-merge workflow for patch and minor updates after CI passes
- Add branch protection script to require status checks before auto-merge

## Test plan
- [ ] Verify Dependabot creates grouped PRs
- [ ] Verify auto-merge works for patch/minor updates
- [ ] Verify major updates require manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)